### PR TITLE
Do not relay on Linux cooked-mode capture (SLL)

### DIFF
--- a/cspv1_can.lua
+++ b/cspv1_can.lua
@@ -56,16 +56,14 @@ function proto_csp1.dissector(buffer, pinfo, tree)
     end
 
     -- get fields
-    local sll_pkt  = sll_pkt_f()
-    local sll_type = sll_type_f()
     local can_xtd  = can_xtd_f()
     local data_len = data_len_f()
     local can_len  = can_len_f()
     local can_pad  = can_pad_f()
 
     -- only CSP packet (possibility)
-    if not(sll_type and can_xtd and data_len) then return end
-    if buffer:len() == 0 or sll_type.value ~= SLL_TYPE_CAN or not(can_xtd.value) then return end
+    if not(can_xtd and data_len) then return end
+    if buffer:len() == 0 or not(can_xtd.value) then return end
 
     local can_pad_len = 0
     if can_pad then
@@ -95,7 +93,7 @@ function proto_csp1.dissector(buffer, pinfo, tree)
     local csp_id     = csp_can_header_big:bitfield(22, 10)
 
     -- table key
-    local key = tostring(sll_pkt) .. ":" .. tostring(csp_src) .. ":" .. tostring(csp_dst) .. ":" .. tostring(csp_id)
+    local key = tostring(csp_src) .. ":" .. tostring(csp_dst) .. ":" .. tostring(csp_id)
 
     -- CSP Extended Header
     if ExtendedTable[key] == nil then

--- a/cspv1_can.lua
+++ b/cspv1_can.lua
@@ -45,16 +45,6 @@ f_data.data  = ProtoField.string("csp1.data", "Data", base.UNICODE)
 
 -- CSP CAN Dissector
 function proto_csp1.dissector(buffer, pinfo, tree)
-    -- 32bit little endian to big endian
-    local function le_to_be(little_bits, start)
-        local buf = ByteArray.new()
-        buf:append(little_bits:bytes(start + 3, 1))
-        buf:append(little_bits:bytes(start + 2, 1))
-        buf:append(little_bits:bytes(start + 1, 1))
-        buf:append(little_bits:bytes(start, 1))
-        return buf:tvb("csp1_can_field big_endian")
-    end
-
     -- get fields
     local can_xtd  = can_xtd_f()
     local data_len = data_len_f()
@@ -79,18 +69,17 @@ function proto_csp1.dissector(buffer, pinfo, tree)
     -- CSP CAN Frame Header
     local csp_can_header = buffer(can_frame_start, 4)
     local can_frame_tree = subtree:add(proto_csp1_can, csp_can_header)
-    can_frame_tree:add_le(f_can.src,    csp_can_header)
-    can_frame_tree:add_le(f_can.dst,    csp_can_header)
-    can_frame_tree:add_le(f_can.flag,   csp_can_header)
-    can_frame_tree:add_le(f_can.remain, csp_can_header)
-    can_frame_tree:add_le(f_can.id,     csp_can_header)
+    can_frame_tree:add(f_can.src,    csp_can_header)
+    can_frame_tree:add(f_can.dst,    csp_can_header)
+    can_frame_tree:add(f_can.flag,   csp_can_header)
+    can_frame_tree:add(f_can.remain, csp_can_header)
+    can_frame_tree:add(f_can.id,     csp_can_header)
 
     -- csp-frame fix endian
-    local csp_can_header_big = le_to_be(buffer, can_frame_start):range(0, 4)
-    local csp_src    = csp_can_header_big:bitfield(3, 5)
-    local csp_dst    = csp_can_header_big:bitfield(8, 5)
-    local csp_remain = csp_can_header_big:bitfield(14, 8)
-    local csp_id     = csp_can_header_big:bitfield(22, 10)
+    local csp_src    = csp_can_header:bitfield(3, 5)
+    local csp_dst    = csp_can_header:bitfield(8, 5)
+    local csp_remain = csp_can_header:bitfield(14, 8)
+    local csp_id     = csp_can_header:bitfield(22, 10)
 
     -- table key
     local key = tostring(csp_src) .. ":" .. tostring(csp_dst) .. ":" .. tostring(csp_id)

--- a/cspv2_can.lua
+++ b/cspv2_can.lua
@@ -55,16 +55,14 @@ function proto_csp.dissector(buffer, pinfo, tree)
     end
 
     -- get fields
-    local sll_pkt  = sll_pkt_f()
-    local sll_type = sll_type_f()
     local can_xtd  = can_xtd_f()
     local data_len = data_len_f()
     local can_len  = can_len_f()
     local can_pad  = can_pad_f()
 
     -- only CSP packet (possibility)
-    if not(sll_type and can_xtd and data_len) then return end
-    if buffer:len() == 0 or sll_type.value ~= SLL_TYPE_CAN or not(can_xtd.value) then return end
+    if not(can_xtd and data_len) then return end
+    if buffer:len() == 0 or not(can_xtd.value) then return end
 
     local can_pad_len = 0
     if can_pad then
@@ -98,7 +96,7 @@ function proto_csp.dissector(buffer, pinfo, tree)
     local csp_end      = csp_can_header_big:bitfield(31, 1)
 
     -- table key
-    local key = tostring(sll_pkt) .. ":" .. tostring(csp_sender) .. ":" .. tostring(csp_dst) .. ":" .. tostring(csp_src_cnt)
+    local key = tostring(csp_sender) .. ":" .. tostring(csp_dst) .. ":" .. tostring(csp_src_cnt)
 
     -- CSP Extended Header
     if csp_begin == 1 then

--- a/cspv2_can.lua
+++ b/cspv2_can.lua
@@ -44,16 +44,6 @@ f_data.data  = ProtoField.string("csp.data", "Data", base.UNICODE)
 
 -- CSP CAN Dissector
 function proto_csp.dissector(buffer, pinfo, tree)
-    -- 32bit little endian to big endian
-    local function le_to_be(little_bits, start)
-        local buf = ByteArray.new()
-        buf:append(little_bits:bytes(start + 3, 1))
-        buf:append(little_bits:bytes(start + 2, 1))
-        buf:append(little_bits:bytes(start + 1, 1))
-        buf:append(little_bits:bytes(start, 1))
-        return buf:tvb("csp_can_field big_endian")
-    end
-
     -- get fields
     local can_xtd  = can_xtd_f()
     local data_len = data_len_f()
@@ -78,22 +68,21 @@ function proto_csp.dissector(buffer, pinfo, tree)
     -- CSP CAN Frame Header
     local csp_can_header = buffer(can_frame_start, 4)
     local can_frame_tree = subtree:add(proto_csp_can, csp_can_header)
-    can_frame_tree:add_le(f_can.prio,             csp_can_header)
-    can_frame_tree:add_le(f_can.destination,      csp_can_header)
-    can_frame_tree:add_le(f_can.sender,           csp_can_header)
-    can_frame_tree:add_le(f_can.source_count,     csp_can_header)
-    can_frame_tree:add_le(f_can.fragment_counter, csp_can_header)
-    can_frame_tree:add_le(f_can.begin,            csp_can_header)
-    can_frame_tree:add_le(f_can.end_,             csp_can_header)
+    can_frame_tree:add(f_can.prio,             csp_can_header)
+    can_frame_tree:add(f_can.destination,      csp_can_header)
+    can_frame_tree:add(f_can.sender,           csp_can_header)
+    can_frame_tree:add(f_can.source_count,     csp_can_header)
+    can_frame_tree:add(f_can.fragment_counter, csp_can_header)
+    can_frame_tree:add(f_can.begin,            csp_can_header)
+    can_frame_tree:add(f_can.end_,             csp_can_header)
 
     -- csp-frame fix endian
-    local csp_can_header_big = le_to_be(buffer, can_frame_start):range(0, 4)
-    local csp_dst      = csp_can_header_big:bitfield(5, 14)
-    local csp_sender   = csp_can_header_big:bitfield(19, 6)
-    local csp_src_cnt  = csp_can_header_big:bitfield(25, 2)
-    local csp_frag_cnt = csp_can_header_big:bitfield(27, 3)
-    local csp_begin    = csp_can_header_big:bitfield(30, 1)
-    local csp_end      = csp_can_header_big:bitfield(31, 1)
+    local csp_dst      = csp_can_header:bitfield(5, 14)
+    local csp_sender   = csp_can_header:bitfield(19, 6)
+    local csp_src_cnt  = csp_can_header:bitfield(25, 2)
+    local csp_frag_cnt = csp_can_header:bitfield(27, 3)
+    local csp_begin    = csp_can_header:bitfield(30, 1)
+    local csp_end      = csp_can_header:bitfield(31, 1)
 
     -- table key
     local key = tostring(csp_sender) .. ":" .. tostring(csp_dst) .. ":" .. tostring(csp_src_cnt)


### PR DESCRIPTION
Linux cooked-mode capture (SLL) is the pseudo-protocol used by libpcap on Linux when capturing on the "any" interface.  If you don't use "any", you won't get it.  That means that if you capture on a one CAN device, the dissectors don't work.

It seems SLL is only used for heuristic determination of CSP packets and for the key, to which sll_pkt is always "1:".

Remove sll.pkttype and sll.ltype so that the dissector works on captures without cooked-mode capture.